### PR TITLE
support growlnotify.exe for windows.

### DIFF
--- a/module/ui/cut-console-ui.c
+++ b/module/ui/cut-console-ui.c
@@ -1139,6 +1139,22 @@ notify_by_growlnotify (CutConsoleUI *console, CutRunContext *run_context,
 
     args = g_ptr_array_new();
     g_ptr_array_add(args, g_strdup(console->notify_command));
+#ifdef G_OS_WIN32
+    g_ptr_array_add(args,
+                    g_strdup_printf("/t:\"%s [%g%%] (%gs)\"",
+                                    status_to_label(status),
+                                    compute_pass_percentage(run_context),
+                                    cut_run_context_get_elapsed(run_context)));
+    if (success) {
+        g_ptr_array_add(args, g_strdup("/p:0"));
+    } else {
+        g_ptr_array_add(args, g_strdup("/p:2"));
+    }
+    if (icon_path) {
+        g_ptr_array_add(args, g_strdup_printf("/i:\"%s\"", icon_path));
+    }
+    g_ptr_array_add(args, g_strdup_printf("%s", format_summary(run_context)));
+#else
     g_ptr_array_add(args, g_strdup("--message"));
     g_ptr_array_add(args, format_summary(run_context));
     g_ptr_array_add(args, g_strdup("--priority"));
@@ -1156,6 +1172,7 @@ notify_by_growlnotify (CutConsoleUI *console, CutRunContext *run_context,
                                     status_to_label(status),
                                     compute_pass_percentage(run_context),
                                     cut_run_context_get_elapsed(run_context)));
+#endif
     g_ptr_array_add(args, NULL);
 
     run_notify_command(console, (gchar **)args->pdata);


### PR DESCRIPTION
growlnotify options are different between growlnotify [_1] and growlnotify.exe. [_2]

so, 'cutter --notify=yes test' does not make sense in windows.

I wrote a tiny patch for growlnotify.exe.

see http://d.hatena.ne.jp/kenhys/20120125  for screenshot.

[1] http://growl.info/extras.php#growlnotify
[2] http://www.growlforwindows.com/gfw/help/growlnotify.aspx
