### PR TITLE
Support of cppcut_assert_equal(const type_info &, const type_info &)

### DIFF
--- a/cppcutter/cppcut-assertions-helper.cpp
+++ b/cppcutter/cppcut-assertions-helper.cpp
@@ -17,6 +17,7 @@
  *
  */
 
+#include <typeinfo>
 #include "cppcut-assertions-helper.h"
 
 CPPCUT_DECL void
@@ -58,6 +59,27 @@ cut::assert_equal(const char *expected, const char *actual,
 {
     cut_assert_equal_string_helper(expected, actual,
                                    expression_expected, expression_actual);
+}
+
+template <>
+CPPCUT_DECL void
+cut::assert_equal_reference<std::type_info>(const std::type_info& expected,
+                                            const std::type_info& actual,
+                                            const char *expression_expected,
+                                            const char *expression_actual)
+{
+    if (expected == actual) {
+        cut_test_pass();
+    } else {
+        std::ostringstream message;
+
+        cut_set_expected(expected.name());
+        cut_set_actual(actual.name());
+
+        message << "<" << expression_expected << " == ";
+        message << expression_actual << ">";
+        cut_test_fail(message.str().c_str());
+    }
 }
 
 CPPCUT_DECL void

--- a/cppcutter/cppcut-assertions-helper.h
+++ b/cppcutter/cppcut-assertions-helper.h
@@ -77,6 +77,10 @@ namespace cut
         }
     }
 
+    template <> void assert_equal_reference<std::type_info>(
+        const std::type_info& expected, const std::type_info& actual,
+        const char *expression_expected, const char *expression_actual);
+
     template <class Type> void assert_equal(const Type *expected,
                                             const Type *actual,
                                             const char *expression_expected,

--- a/test/cppcutter/test-cppcut-assertions.cpp
+++ b/test/cppcutter/test-cppcut-assertions.cpp
@@ -17,6 +17,7 @@
  *
  */
 
+#include <typeinfo>
 #include <cppcutter.h>
 #include <cutter/cut-test.h>
 #include <cutter/cut-test-result.h>
@@ -432,6 +433,32 @@ namespace cppcut_assertion_equal
                                "\"abcde\"", "\"ABcDE\"",
                                FAIL_LOCATION,
                                "void cppcut_assertion_equal::stub_string()",
+                               NULL);
+    }
+
+    static void
+    stub_type_info (void)
+    {
+        cppcut_assert_equal(typeid(int), typeid(1));
+        MARK_FAIL(cppcut_assert_equal(typeid(int), typeid(1.0)));
+    }
+
+    void
+    test_type_info (void)
+    {
+        test = cut_test_new("equal_type_info test", stub_type_info);
+        cut_assert_not_null(test);
+
+        cut_assert_false(run());
+        cut_assert_test_result_summary(run_context, 1, 1, 0, 1, 0, 0, 0, 0);
+        cut_assert_test_result(run_context, 0, CUT_TEST_RESULT_FAILURE,
+                               "equal_type_info test",
+                               NULL,
+                               "<typeid(int) == typeid(1.0)>",
+                               cut_take_printf("%s", typeid(int).name()),
+                               cut_take_printf("%s", typeid(double).name()),
+                               FAIL_LOCATION,
+                               "void cppcut_assertion_equal::stub_type_info()",
                                NULL);
     }
 }


### PR DESCRIPTION
The previous version fails to build a test with the above
expression, because the class: type_info doesn't have an
operator<<() for getting the object content.
This patch gets it with type_info.name() in the newly-added
specilized template function.
