### PR TITLE
Catch unhandled C++ exceptions and avoid a crash

### DIFF
--- a/cutter/Makefile.am
+++ b/cutter/Makefile.am
@@ -8,6 +8,8 @@ AM_CFLAGS =					\
 	$(CUTTER_CFLAGS)			\
 	$(COVERAGE_CFLAGS)
 
+AM_CXXFLAGS = $(AM_CFLAGS)
+
 CLEANFILES = *.gcno *.gcda
 
 lib_LTLIBRARIES = libcutter.la
@@ -169,6 +171,7 @@ libcutter_sources =			\
 	cut-test-suite.c		\
 	cut-test-utils-helper.c		\
 	cut-test.c			\
+	cut-test-cpp-helpers.cpp	\
 	cut-ui-factory-builder.c	\
 	cut-ui.c			\
 	cut-unified-differ.c		\

--- a/cutter/cut-test-cpp-helpers.cpp
+++ b/cutter/cut-test-cpp-helpers.cpp
@@ -1,0 +1,46 @@
+/* -*- Mode: C; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+/*
+ *  Copyright (C) 2014  Kazuhiro Yamato <kz0817@gmail.com>
+ *
+ *  This library is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifdef HAVE_CONFIG_H
+#  include <config.h>
+#endif /* HAVE_CONFIG_H */
+
+#include <exception>
+#include <typeinfo>
+#include "cut-helper.h"
+#include "cut-test-cpp-helpers.h"
+
+void
+cut_test_cpp_safe_invoke (void (*func)(void))
+{
+    try {
+        (*func)();
+    } catch (const std::exception &e) {
+        cut_test_terminate(ERROR,
+                           cut_take_printf("received a C++ exception: <%s> %s",
+                                           typeid(e).name(), e.what()));
+    } catch (...) {
+        cut_test_terminate(ERROR,
+                           cut_take_printf("received a C++ exception"));
+    }
+}
+
+/*
+vi:ts=4:nowrap:ai:expandtab:sw=4
+*/

--- a/cutter/cut-test-cpp-helpers.h
+++ b/cutter/cut-test-cpp-helpers.h
@@ -1,0 +1,36 @@
+/* -*- Mode: C; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+/*
+ *  Copyright (C) 2014  Kazuhiro Yamato <kz0817@gmail.com>
+ *
+ *  This library is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef __CUT_TEST_CPP_HELPERS_H__
+#define __CUT_TEST_CPP_HELPERS_H__
+
+#include <glib.h>
+#include "cut-test.h"
+
+G_BEGIN_DECLS
+
+void        cut_test_cpp_safe_invoke (CutTestFunction func);
+
+G_END_DECLS
+
+#endif /* __CUT_TEST_H__ */
+
+/*
+vi:ts=4:nowrap:ai:expandtab:sw=4
+*/

--- a/cutter/cut-test.c
+++ b/cutter/cut-test.c
@@ -28,6 +28,7 @@
 #include <glib.h>
 
 #include "cut-test.h"
+#include "cut-test-cpp-helpers.h"
 #include "cut-test-container.h"
 #include "cut-run-context.h"
 #include "cut-test-result.h"
@@ -419,7 +420,7 @@ invoke (CutTest *test, CutTestContext *test_context, CutRunContext *run_context)
     priv = CUT_TEST_GET_PRIVATE(test);
     if (cut_run_context_get_stop_before_test(run_context))
         G_BREAKPOINT();
-    priv->test_function();
+    cut_test_cpp_safe_invoke(priv->test_function);
 }
 
 static gboolean

--- a/test/cutter/Makefile.am
+++ b/test/cutter/Makefile.am
@@ -8,6 +8,8 @@ AM_CFLAGS =			\
 	$(CUTTER_CFLAGS)	\
 	$(GTK_CFLAGS)
 
+AM_CXXFLAGS = $(AM_CFLAGS)
+
 CLEANFILES = *.gcno *.gcda
 
 check_LTLIBRARIES =			\
@@ -50,7 +52,8 @@ check_LTLIBRARIES =			\
 	test-cut-path.la		\
 	test-cut-test-utils.la		\
 	test-cut-thread.la		\
-	test-cut-logger.la
+	test-cut-logger.la		\
+	test-cut-cpp-helpers.la
 
 AM_LDFLAGS =			\
 	-module			\
@@ -108,6 +111,7 @@ test_cut_path_la_SOURCES		= test-cut-path.c
 test_cut_test_utils_la_SOURCES		= test-cut-test-utils.c
 test_cut_thread_la_SOURCES		= test-cut-thread.c
 test_cut_logger_la_SOURCES		= test-cut-logger.c
+test_cut_cpp_helpers_la_SOURCES		= test-cut-cpp-helpers.cpp
 
 echo-tests:
 	@echo $(noinst_LTLIBRARIES)

--- a/test/cutter/test-cut-cpp-helpers.cpp
+++ b/test/cutter/test-cut-cpp-helpers.cpp
@@ -1,0 +1,127 @@
+/* -*- Mode: C; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#ifdef HAVE_CONFIG_H
+#  include <config.h>
+#endif
+
+#include <exception>
+#include <typeinfo>
+#include <string>
+#include <cutter.h>
+#include <cutter/cut-test.h>
+#include <cutter/cut-test-runner.h>
+
+#include "../lib/cuttest-assertions.h"
+
+static CutTest *test;
+static CutRunContext *run_context;
+static CutTestContext *test_context;
+
+class test_exception : public std::exception {
+public:
+    virtual const char *
+    what(void) const throw() // override
+    {
+        return message;
+    }
+
+    static const char *message;
+};
+const char *test_exception::message = "Test exception";
+
+extern "C"
+void
+cut_setup (void)
+{
+    test = NULL;
+    run_context = NULL;
+    test_context = NULL;
+}
+
+extern "C"
+void
+cut_teardown (void)
+{
+    if (test)
+        g_object_unref(test);
+    if (run_context)
+        g_object_unref(run_context);
+    if (test_context)
+        g_object_unref(test_context);
+}
+
+static gboolean
+run (void)
+{
+    gboolean success;
+
+    run_context = CUT_RUN_CONTEXT(cut_test_runner_new());
+    test_context = cut_test_context_new(run_context, NULL, NULL, NULL, test);
+    cut_test_context_current_push(test_context);
+    success = cut_test_runner_run_test(CUT_TEST_RUNNER(run_context),
+                                       test, test_context);
+    cut_test_context_current_pop();
+    return success;
+}
+
+static void
+stub_throw_std_exception (void)
+{
+    throw test_exception();
+}
+
+static void
+stub_throw_non_std_exception (void)
+{
+    throw 1;
+}
+
+static std::string
+expected_system_message (const bool &is_std_exception)
+{
+    test_exception e;
+    std::string expected = "received a C++ exception";
+    if (is_std_exception) {
+        expected += ": <";
+        expected += typeid(test_exception).name();
+        expected += "> ";
+        expected += test_exception::message;
+    }
+    return expected;
+}
+
+extern "C"
+void
+test_catch_unhandled_std_exception (void)
+{
+    test = cut_test_new("catch an unhandled C++ standard exception",
+                        stub_throw_std_exception);
+    cut_assert_false(run());
+    cut_assert_test_result_summary(run_context, 1, 0, 0, 0, 1, 0, 0, 0);
+    cut_assert_test_result(run_context, 0, CUT_TEST_RESULT_ERROR,
+                           "catch an unhandled C++ standard exception",
+                           NULL,
+                           expected_system_message(true).c_str(),
+                           NULL, NULL, NULL,
+                           NULL);
+}
+
+extern "C"
+void
+test_catch_unhandled_non_std_exception (void)
+{
+    test = cut_test_new("catch an unhandled C++ non-standard exception",
+                        stub_throw_non_std_exception);
+    cut_assert_false(run());
+    cut_assert_test_result_summary(run_context, 1, 0, 0, 0, 1, 0, 0, 0);
+    cut_assert_test_result(run_context, 0, CUT_TEST_RESULT_ERROR,
+                           "catch an unhandled C++ non-standard exception",
+                           NULL,
+                           expected_system_message(false).c_str(),
+                           NULL, NULL, NULL,
+                           NULL);
+}
+
+/*
+vi:ts=4:nowrap:ai:expandtab:sw=4
+*/


### PR DESCRIPTION
Although cutter supports a test of C++ code, it crashes when a C++
exception is leaked outside of a test case. However, some C++
libraries and programs use an exception to notify an error.

A workaround by surrounding with a try-catch block makes simplicity
of test code degrade. In addition, different from Java, C++ doesn't
mandate an declaration of exceptions that may be thrown. As a result,
unexpected exceptions sometimes appear from deep within the call stack.

This patch catches C++ exceptions at right outside of a test
case without any additional lines of a test case (i.e. maintains
compatibility of test code), and labels the test as an error.
