### PR TITLE
Fix a potential problem that may read uninitialized memory region on a stack.

### DIFF
--- a/cutter/cut-elf-loader.c
+++ b/cutter/cut-elf-loader.c
@@ -182,6 +182,7 @@ cut_elf_loader_is_elf (CutELFLoader *loader)
         return FALSE;
     }
 
+    bzero(ident, EI_NIDENT);
     if (priv->length >= sizeof(ident))
         memcpy(ident, priv->content, sizeof(ident));
 


### PR DESCRIPTION
This problem was warned by gcc 4.8.1 on Ubuntu 13.10 as below.

cut-elf-loader.c: In function 'cut_elf_loader_is_elf':
cut-elf-loader.c:191:37: warning: 'ident[3]' may be used uninitialized in this function [-Wmaybe-uninitialized](ident[EI_MAG2] == ELFMAG2) &&
                                     ^
cut-elf-loader.c:190:37: warning: 'ident[2]' may be used uninitialized in this function [-Wmaybe-uninitialized](ident[EI_MAG1] == ELFMAG1) &&
                                     ^
cut-elf-loader.c:189:37: warning: 'ident[1]' may be used uninitialized in this function [-Wmaybe-uninitialized]
     if ((ident[EI_MAG0] == ELFMAG0) &&
                                     ^
cut-elf-loader.c:189:8: warning: 'ident[0]' may be used uninitialized in this function [-Wmaybe-uninitialized]
     if ((ident[EI_MAG0] == ELFMAG0) &&
