### PR TITLE
Unwind jump buffers to avoid an invalid memory access on an unhandled exception

### DIFF
--- a/cppcutter/cppcut-test-methods.cpp
+++ b/cppcutter/cppcut-test-methods.cpp
@@ -46,6 +46,15 @@ struct CppCutTestTerminated {
 
 static const gchar *invoking_data_key = "cppcut-test-invoking";
 
+static void
+force_unwind_jump_buffers (CutTest *test)
+{
+    CutTestContext *test_context = cut_get_current_test_context();
+    while (cut_test_context_in_user_message_jump(test_context))
+        cut_test_context_finish_user_message_jump(test_context);
+    cut_test_context_set_jump_buffer(test_context, cut_test_get_jump_buffer(test));
+}
+
 void
 cut::test::long_jump (CutTestClass  *cut_test_class,
                       CutTest       *test,
@@ -100,6 +109,7 @@ cut::test::invoke (CutTestClass *cut_test_class,
     }
 
     if (terminate_message) {
+        force_unwind_jump_buffers(test);
         cut_test_terminate(ERROR, terminate_message);
     }
 }

--- a/cutter/cut-test.c
+++ b/cutter/cut-test.c
@@ -551,6 +551,13 @@ cut_test_is_own_jump_buffer (CutTest *test, jmp_buf *jump_buffer)
     return priv->jump_buffer == jump_buffer;
 }
 
+jmp_buf *
+cut_test_get_jump_buffer (CutTest *test)
+{
+    CutTestPrivate *priv = CUT_TEST_GET_PRIVATE(test);
+    return priv->jump_buffer;
+}
+
 const gchar *
 cut_test_get_name (CutTest *test)
 {

--- a/cutter/cut-test.h
+++ b/cutter/cut-test.h
@@ -118,6 +118,7 @@ void         cut_test_long_jump           (CutTest        *test,
                                            gint            value);
 gboolean     cut_test_is_own_jump_buffer  (CutTest        *test,
                                            jmp_buf        *jump_buffer);
+jmp_buf     *cut_test_get_jump_buffer     (CutTest        *test);
 
 const gchar *cut_test_get_name            (CutTest     *test);
 void         cut_test_set_name            (CutTest     *test,


### PR DESCRIPTION
If jump buffers are stacked, the previous catch handler calls
longjmp() with the top of the jump buffers. However, it is no
longer valid, because it was on a stack unwound by the exception.
This situation typically happens when an exception is thrown in
cutter's assertion function.

This patch forces to use the base jump buffer when an unhandled
exception is caught.
