### PR TITLE
Fix double free.

### DIFF
--- a/cutter/cut-main.c
+++ b/cutter/cut-main.c
@@ -398,14 +398,12 @@ cut_quit (void)
 
     if (listener_factories) {
         g_list_foreach(listener_factories, (GFunc)g_object_unref, NULL);
-        g_list_free(listener_factories);
         listener_factories = NULL;
     }
 
     if (loader_customizer_factories) {
         g_list_foreach(loader_customizer_factories,
                        (GFunc)g_object_unref, NULL);
-        g_list_free(loader_customizer_factories);
         loader_customizer_factories = NULL;
     }
 


### PR DESCRIPTION
GList objects 'listener_factories' and 'loader_customizer_factories' are
owned by a cut-contractor object. The current implementation rightly
deletes them in the destructor of cut-contractor.
However, cut-main which has the lists as a referece also deletes them and
causes double free. As a result, a crash sometimes happens.
# 

The following is a trace log with Valgrind before this patch is applied.

==12667== Invalid read of size 8
==12667==    at 0x5EB6428: g_slice_free_chain_with_offset (gslice.c:1213)
==12667==    by 0x4E5D2CF: dispose (cut-factory-builder.c:109)
==12667==    by 0x5C15ABB: g_object_unref (gobject.c:3160)
==12667==    by 0x5E96EE7: g_list_foreach (glist.c:949)
==12667==    by 0x4E5AD12: dispose (cut-contractor.c:128)
==12667==    by 0x5C15ABB: g_object_unref (gobject.c:3160)
==12667==    by 0x4E611A0: cut_quit (cut-main.c:414)
==12667==    by 0x400785: main (main.c:36)
==12667==  Address 0x6e3ec08 is 8 bytes inside a block of size 24 free'd
==12667==    at 0x4C2BC47: free (vg_replace_malloc.c:469)
==12667==    by 0x5EB6414: g_slice_free_chain_with_offset (gslice.c:1219)
==12667==    by 0x4E61153: cut_quit (cut-main.c:402)
==12667==    by 0x400785: main (main.c:36)
==12667==
==12667== Invalid free() / delete / delete[] / realloc()
==12667==    at 0x4C2BC47: free (vg_replace_malloc.c:469)
==12667==    by 0x5EB6414: g_slice_free_chain_with_offset (gslice.c:1219)
==12667==    by 0x4E5D2CF: dispose (cut-factory-builder.c:109)
==12667==    by 0x5C15ABB: g_object_unref (gobject.c:3160)
==12667==    by 0x5E96EE7: g_list_foreach (glist.c:949)
==12667==    by 0x4E5AD12: dispose (cut-contractor.c:128)
==12667==    by 0x5C15ABB: g_object_unref (gobject.c:3160)
==12667==    by 0x4E611A0: cut_quit (cut-main.c:414)
==12667==    by 0x400785: main (main.c:36)
==12667==  Address 0x6e3ec00 is 0 bytes inside a block of size 24 free'd
==12667==    at 0x4C2BC47: free (vg_replace_malloc.c:469)
==12667==    by 0x5EB6414: g_slice_free_chain_with_offset (gslice.c:1219)
==12667==    by 0x4E61153: cut_quit (cut-main.c:402)
==12667==    by 0x400785: main (main.c:36)
==12667==
==12667== Invalid read of size 8
==12667==    at 0x5EB6428: g_slice_free_chain_with_offset (gslice.c:1213)
==12667==    by 0x4E5D2CF: dispose (cut-factory-builder.c:109)
==12667==    by 0x5C15ABB: g_object_unref (gobject.c:3160)
==12667==    by 0x4E5AD2F: dispose (cut-contractor.c:134)
==12667==    by 0x5C15ABB: g_object_unref (gobject.c:3160)
==12667==    by 0x4E611A0: cut_quit (cut-main.c:414)
==12667==    by 0x400785: main (main.c:36)
==12667==  Address 0x6e40c58 is 8 bytes inside a block of size 24 free'd
==12667==    at 0x4C2BC47: free (vg_replace_malloc.c:469)
==12667==    by 0x5EB6414: g_slice_free_chain_with_offset (gslice.c:1219)
==12667==    by 0x4E61184: cut_quit (cut-main.c:409)
==12667==    by 0x400785: main (main.c:36)
