### PR TITLE
*USERS*: add Hatohol.

### DIFF
--- a/USERS
+++ b/USERS
@@ -28,3 +28,5 @@
 #  * ((<Poppler|URL:http://poppler.freedesktop.org/>)):
 #    PDF rendering library.
 #
+  * ((<Hatohol|URL:https://github.com/project-hatohol/hatohol>)):
+    Operational integrated management software

--- a/USERS.ja
+++ b/USERS.ja
@@ -27,3 +27,5 @@
 #  * ((<Poppler|URL:http://poppler.freedesktop.org/>)): PDF
 #    レンダリングライブラリ
   * ((<海野さん|URL:http://uhideyuki.sakura.ne.jp/uDiary/?category=Cutter>))
+  * ((<Hatohol|URL:https://github.com/project-hatohol/hatohol>)):
+    運用統合管理ソフトウェア


### PR DESCRIPTION
I report that our project is using cutter at "Hatohol".

Hatohol is operational integrated management software.
We use cutter to do unit test of module.

If there is no problem, please merge this.
