### PR TITLE
add support terminal-notifier notification

### DIFF
--- a/module/ui/cut-console-ui-factory.c
+++ b/module/ui/cut-console-ui-factory.c
@@ -329,6 +329,7 @@ search_notify_command (void)
 {
     const gchar *notify_send = "notify-send";
     const gchar *growlnotify = "growlnotify";
+    const gchar *terminal_notifier = "terminal-notifier";
 
     if (program_exist(notify_send) &&
         g_getenv("DBUS_SESSION_BUS_ADDRESS")) {
@@ -337,6 +338,10 @@ search_notify_command (void)
 
     if (program_exist(growlnotify)) {
         return growlnotify;
+    }
+
+    if (program_exist(terminal_notifier)) {
+        return terminal_notifier;
     }
 
     return NULL;

--- a/module/ui/cut-console-ui.c
+++ b/module/ui/cut-console-ui.c
@@ -1229,6 +1229,35 @@ notify_by_notify_send (CutConsoleUI *console, CutRunContext *run_context,
 }
 
 static void
+notify_by_terminal_notifier (CutConsoleUI *console, CutRunContext *run_context,
+                             gboolean success)
+{
+    GPtrArray *args;
+    CutTestResultStatus status;
+    gchar *icon_path;
+
+    status = cut_run_context_get_status(run_context);
+    icon_path = search_icon_path(status, success);
+
+    args = g_ptr_array_new();
+    g_ptr_array_add(args, g_strdup(console->notify_command));
+    g_ptr_array_add(args, g_strdup("-title"));
+    g_ptr_array_add(args, format_notify_message(run_context));
+    g_ptr_array_add(args, g_strdup("-message"));
+    g_ptr_array_add(args, format_summary(run_context));
+    if (icon_path) {
+        g_ptr_array_add(args, g_strdup("-appIcon"));
+        g_ptr_array_add(args, icon_path);
+    }
+    g_ptr_array_add(args, NULL);
+
+    run_notify_command(console, (gchar **)args->pdata);
+
+    g_ptr_array_foreach(args, (GFunc)g_free, NULL);
+    g_ptr_array_free(args, TRUE);
+}
+
+static void
 notify (CutConsoleUI *console, CutRunContext *run_context, gboolean success)
 {
     if (!console->notify_command)
@@ -1238,6 +1267,8 @@ notify (CutConsoleUI *console, CutRunContext *run_context, gboolean success)
         notify_by_notify_send(console, run_context, success);
     } else if (strcmp(console->notify_command, "growlnotify") == 0) {
         notify_by_growlnotify(console, run_context, success);
+    } else if (strcmp(console->notify_command, "terminal-notifier") == 0) {
+        notify_by_terminal_notifier(console, run_context, success);
     }
 }
 


### PR DESCRIPTION
How about support `terminal-notifier` notification in OS X environment?

like this:
![cutter-terminal-notifier-support](https://cloud.githubusercontent.com/assets/700876/4827746/bf793d24-5f7a-11e4-9194-79320249eb0b.png)
