### PR TITLE
doc debian ja: fix apt-line

### DIFF
--- a/doc/install-to-debian.rd.ja
+++ b/doc/install-to-debian.rd.ja
@@ -21,15 +21,15 @@ wheezyの場合は以下のapt lineを書いた
 /etc/apt/sources.list.d/cutter.listを作成してください。
 
 /etc/apt/sources.list.d/cutter.list:
-  deb http://downloads.sourceforge.net/project/cutter/files/debian/ wheezy main
-  deb-src http://downloads.sourceforge.net/project/cutter/files/debian/ wheezy main
+  deb http://downloads.sourceforge.net/project/cutter/debian/ wheezy main
+  deb-src http://downloads.sourceforge.net/project/cutter/debian/ wheezy main
 
 jessieの場合は以下のapt lineを書いた
 /etc/apt/sources.list.d/cutter.listを作成してください。
 
 /etc/apt/sources.list.d/cutter.list:
-  deb http://downloads.sourceforge.net/project/cutter/files/debian/ jessie main
-  deb-src http://downloads.sourceforge.net/project/cutter/files/debian/ jessie main
+  deb http://downloads.sourceforge.net/project/cutter/debian/ jessie main
+  deb-src http://downloads.sourceforge.net/project/cutter/debian/ jessie main
 
 Cutterパッケージはcutter-keyringが提供している鍵で署名されています。
 cutter-keyringパッケージをインストールして鍵を登録してください。


### PR DESCRIPTION
supplement to e0c664134604286ed0b31eb7c2552e07e658d8f9 (the last commit).
Remove `files/` from Japanese translation as long as English one.
