### PR TITLE
Use Unicode in translatable strings since GLib 2.52.0

### DIFF
--- a/cutter/cut-main.c
+++ b/cutter/cut-main.c
@@ -278,8 +278,13 @@ cut_init (int *argc, char ***argv)
         g_strdup_printf(N_("TEST_DIRECTORY\n"
                            "  %s --mode=analyze %s LOG_DIRECTORY\n"
                            "  %s --mode=play %s LOG_FILE"),
+#if GLIB_CHECK_VERSION(2, 52, 0)
+                        program_name, _("[OPTION…]"),
+                        program_name, _("[OPTION…]"));
+#else
                         program_name, _("[OPTION...]"),
                         program_name, _("[OPTION...]"));
+#endif
     option_context = g_option_context_new(parameter_string);
     g_free(program_name);
     g_free(parameter_string);

--- a/test/cutter/test-cutter.c
+++ b/test/cutter/test-cutter.c
@@ -85,9 +85,15 @@ cut_setup (void)
 
     format =
         "Usage:" LINE_FEED_CODE
+#if GLIB_CHECK_VERSION(2, 52, 0)
+        "  %s [OPTION…] TEST_DIRECTORY" LINE_FEED_CODE
+        "  %s --mode=analyze [OPTION…] LOG_DIRECTORY" LINE_FEED_CODE
+        "  %s --mode=play [OPTION…] LOG_FILE" LINE_FEED_CODE
+#else
         "  %s [OPTION...] TEST_DIRECTORY" LINE_FEED_CODE
         "  %s --mode=analyze [OPTION...] LOG_DIRECTORY" LINE_FEED_CODE
         "  %s --mode=play [OPTION...] LOG_FILE" LINE_FEED_CODE
+#endif
         "" LINE_FEED_CODE
         "Help Options:" LINE_FEED_CODE
 #if GLIB_CHECK_VERSION(2, 21, 0)

--- a/test/cutter/test-cutter.c
+++ b/test/cutter/test-cutter.c
@@ -219,9 +219,15 @@ test_help_all (void)
 
     format =
         "Usage:" LINE_FEED_CODE
+#if GLIB_CHECK_VERSION(2, 52, 0)
+        "  %s [OPTION…] TEST_DIRECTORY" LINE_FEED_CODE
+        "  %s --mode=analyze [OPTION…] LOG_DIRECTORY" LINE_FEED_CODE
+        "  %s --mode=play [OPTION…] LOG_FILE" LINE_FEED_CODE
+#else
         "  %s [OPTION...] TEST_DIRECTORY" LINE_FEED_CODE
         "  %s --mode=analyze [OPTION...] LOG_DIRECTORY" LINE_FEED_CODE
         "  %s --mode=play [OPTION...] LOG_FILE" LINE_FEED_CODE
+#endif
         "" LINE_FEED_CODE
         "Help Options:" LINE_FEED_CODE
 #if GLIB_CHECK_VERSION(2, 21, 0)

--- a/test/cutter/test-cutter.c
+++ b/test/cutter/test-cutter.c
@@ -163,6 +163,7 @@ run_cutter (const gchar *options)
     cut_assert(cutter_command);
 
     g_setenv("LANG", "C", TRUE);
+    g_setenv("CHARSET", "UTF-8", TRUE);
 
     if (options)
         command = g_strdup_printf("\"%s\" %s", cutter_command, options);

--- a/test/cutter/test-cutter.c
+++ b/test/cutter/test-cutter.c
@@ -59,6 +59,7 @@ static gchar *stdout_string = NULL;
 static gchar *stderr_string = NULL;
 static gint exit_status = 0;
 static gchar *lang = NULL;
+static gchar *charset = NULL;
 
 static const gchar *help_message;
 
@@ -82,6 +83,7 @@ cut_setup (void)
     stderr_string = NULL;
     exit_status = 0;
     lang = g_strdup(g_getenv("LANG"));
+    charset = g_strdup(g_getenv("CHARSET"));
 
     format =
         "Usage:" LINE_FEED_CODE
@@ -147,6 +149,12 @@ cut_teardown (void)
         g_free(lang);
     } else {
         g_unsetenv("LANG");
+    }
+    if (charset) {
+        g_setenv("CHARSET", charset, TRUE);
+        g_free(charset);
+    } else {
+        g_unsetenv("CHARSET ");
     }
 }
 

--- a/test/gcutter/test-gcut-egg.c
+++ b/test/gcutter/test-gcut-egg.c
@@ -190,7 +190,11 @@ test_flags (void)
     cut_assert_false(gcut_egg_hatch(egg, &actual_error));
     expected_error =
         g_error_new(G_SPAWN_ERROR, G_SPAWN_ERROR_NOENT,
+#if GLIB_CHECK_VERSION(2, 52, 0)
+                    "Failed to execute child process “%s” (%s)",
+#else
                     "Failed to execute child process \"%s\" (%s)",
+#endif
                     command, g_strerror(ENOENT));
     gcut_assert_equal_error(expected_error, actual_error);
 

--- a/test/gcutter/test-gcut-key-file.c
+++ b/test/gcutter/test-gcut-key-file.c
@@ -136,9 +136,14 @@ data_get_enum (void)
                      0,
                      g_error_new(G_KEY_FILE_ERROR,
                                  G_KEY_FILE_ERROR_KEY_NOT_FOUND,
+#if GLIB_CHECK_VERSION(2, 52, 0)
+                                 "Key file does not have key “unknown-key”"
+                                 " in group “group”"
+#else
                                  "Key file does not have key 'unknown-key'"
 #if GLIB_CHECK_VERSION(2, 43, 0)
                                  " in group 'group'"
+#endif
 #endif
                                 )),
                  enum_test_data_free,
@@ -222,9 +227,14 @@ data_get_flags (void)
                      0,
                      g_error_new(G_KEY_FILE_ERROR,
                                  G_KEY_FILE_ERROR_KEY_NOT_FOUND,
+#if GLIB_CHECK_VERSION(2, 52, 0)
+                                 "Key file does not have key “unknown-key”"
+                                 " in group “group”"
+#else
                                  "Key file does not have key 'unknown-key'"
-#if GLIB_CHECK_VERSION(2, 43, 0)
+#  if GLIB_CHECK_VERSION(2, 43, 0)
                                  " in group 'group'"
+#  endif
 #endif
                                 )),
                  enum_test_data_free,

--- a/test/gcutter/test-gcut-process.c
+++ b/test/gcutter/test-gcut-process.c
@@ -234,7 +234,11 @@ test_flags (void)
     cut_assert_false(gcut_process_run(process, &actual_error));
     expected_error =
         g_error_new(G_SPAWN_ERROR, G_SPAWN_ERROR_NOENT,
+#if GLIB_CHECK_VERSION(2, 52, 0)
+                    "Failed to execute child process “%s” (%s)",
+#else
                     "Failed to execute child process \"%s\" (%s)",
+#endif
                     "echo", g_strerror(ENOENT));
     gcut_assert_equal_error(expected_error, actual_error);
 


### PR DESCRIPTION
See:
  * https://developer.gnome.org/hig/stable/typography.html
  * https://bugzilla.gnome.org/show_bug.cgi?id=772221