### PR TITLE
avoid build failure on non-UTF-8 environment

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -94,7 +94,7 @@ RD2MAN = $(RUBY) -I $(RD2LIB_DIR) $(RD2) -r $(RD2MAN_LIB_FILE)
 	$(RD2MAN) $< > $@
 
 .rd.jman: # dirty...
-	$(RD2MAN) $<.ja > $@
+	LC_ALL=en_US.UTF-8 $(RD2MAN) $<.ja > $@
 
 .svg.png:
 	inkscape --export-png $@ $<


### PR DESCRIPTION
In certain enviroment (like Debian's pbuilder, for example), it fails to build
as below.

> /usr/bin/ruby -I ../misc /usr/bin/rd2 -r rd2man-lib.rb cutter.rd.ja > cutter.jman
> /usr/bin/rd2:209:in `===': invalid byte sequence in US-ASCII (ArgumentError)
>         from /usr/bin/rd2:209:in `block in <main>'
>         from /usr/bin/rd2:209:in `each'
>         from /usr/bin/rd2:209:in `find'
>         from /usr/bin/rd2:209:in `<main>'
> Makefile:893: recipe for target 'cutter.jman' failed
> make[4]: *** [cutter.jman] Error 1

Specifying LC_ALL can fix it.