### PR TITLE
doc: modernize documentation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -555,7 +555,7 @@ dnl Checks for gtk-doc
 dnl **************************************************************
 
 m4_ifdef([GTK_DOC_CHECK],
-         [GTK_DOC_CHECK([1.10],[--flavour no-tmpl])],
+         [GTK_DOC_CHECK([1.16],[--flavour no-tmpl])],
          [enable_gtk_doc=no
           AM_CONDITIONAL([GTK_DOC_USE_LIBTOOL], [false])
           AM_CONDITIONAL([ENABLE_GTK_DOC], [false])])

--- a/configure.ac
+++ b/configure.ac
@@ -555,7 +555,7 @@ dnl Checks for gtk-doc
 dnl **************************************************************
 
 m4_ifdef([GTK_DOC_CHECK],
-         [GTK_DOC_CHECK([1.9],[--flavour no-tmpl])],
+         [GTK_DOC_CHECK([1.10],[--flavour no-tmpl])],
          [enable_gtk_doc=no
           AM_CONDITIONAL([GTK_DOC_USE_LIBTOOL], [false])
           AM_CONDITIONAL([ENABLE_GTK_DOC], [false])])

--- a/configure.ac
+++ b/configure.ac
@@ -555,7 +555,7 @@ dnl Checks for gtk-doc
 dnl **************************************************************
 
 m4_ifdef([GTK_DOC_CHECK],
-         [GTK_DOC_CHECK([1.8])],
+         [GTK_DOC_CHECK([1.9],[--flavour no-tmpl])],
          [enable_gtk_doc=no
           AM_CONDITIONAL([GTK_DOC_USE_LIBTOOL], [false])
           AM_CONDITIONAL([ENABLE_GTK_DOC], [false])])

--- a/doc/reference/Makefile.am
+++ b/doc/reference/Makefile.am
@@ -20,6 +20,7 @@ GTKDOC_CFLAGS =						\
 # Extra options to supply to gtkdoc-scan
 SCAN_OPTIONS =						\
 	--deprecated-guards="CUTTER_DISABLE_DEPRECATED"	\
+	--rebuild-types					\
 	$(SOURCE_DIR_OPTIONS)
 
 # Extra options to supply to gtkdoc-scangobj

--- a/doc/reference/Makefile.am
+++ b/doc/reference/Makefile.am
@@ -199,6 +199,13 @@ content_files =					\
 # Extra options to supply to gtkdoc-fixxref
 FIXXREF_OPTIONS=
 
+if ENABLE_GTK_DOC
+TESTS_ENVIRONMENT = \
+	DOC_MODULE=$(DOC_MODULE) DOC_MAIN_SGML_FILE=$(DOC_MAIN_SGML_FILE) \
+	SRCDIR=$(abs_srcdir) BUILDDIR=$(abs_builddir)
+TESTS = $(GTKDOC_CHECK)
+endif
+
 CATALOGS=ja.po
 
 # include common portion ...

--- a/doc/reference/cutter.types
+++ b/doc/reference/cutter.types
@@ -1,5 +1,0 @@
-gcut_egg_get_type
-gcut_process_get_type
-gcut_dynamic_data_get_type
-gcut_event_loop_get_type
-soupcut_client_get_type


### PR DESCRIPTION
See https://developer.gnome.org/gtk-doc-manual/stable/modernizing.html.en

TODO: drop gtkdoc-mktmpl 