### PR TITLE
doc: support to regenerate gtk-doc.make

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -554,11 +554,11 @@ dnl **************************************************************
 dnl Checks for gtk-doc
 dnl **************************************************************
 
-m4_ifdef([GTK_DOC_CHECK],
-         [GTK_DOC_CHECK([1.16],[--flavour no-tmpl])],
-         [enable_gtk_doc=no
-          AM_CONDITIONAL([GTK_DOC_USE_LIBTOOL], [false])
-          AM_CONDITIONAL([ENABLE_GTK_DOC], [false])])
+m4_ifdef([GTK_DOC_CHECK], [
+GTK_DOC_CHECK([1.16],[--flavour no-tmpl])
+], [enable_gtk_doc=no
+    AM_CONDITIONAL([GTK_DOC_USE_LIBTOOL], [false])
+    AM_CONDITIONAL([ENABLE_GTK_DOC], [false])])
 
 dnl **************************************************************
 dnl Checks for Ruby


### PR DESCRIPTION
gtkdocize checks whether GTK_DOC_CHECK macro
exists on beginning of line.

ref. https://github.com/GNOME/gtk-doc/blob/master/gtkdocize.in#L60

This commit skips such a check in gtkdocize.